### PR TITLE
Add --proxy option to proxy requests to another server

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -112,6 +112,11 @@ When _elm make_ encounters a compile error, we keep _elm-live_ running and give 
 #### `--pushstate`
 Serve `index.html` on 404 errors. This lets us use client-side routing in Elm. For instance, we can have a URL like `http://localhost:8000/account` get handled by the Elm _navigation_ package instead of failing with a 404 error.
 
+#### `--proxy=PATH_PREFIX::HOST(::STRIP_PREFIX)
+Proxy requests to paths that start with `PATH_PREFIX` to another server runing at `HOST`. This can be helpful when developing against a backend server serving an API.
+If `STRIP_PREFIX` is given, it will be removed from the start of the path before being proxied.
+As an example `--proxy=/api::http://localhost:8080::/api` will result in requests to `/api/posts` to be proxied to `http://localhost:8080/posts`.
+
 #### `--before-build=EXECUTABLE`
 Run `EXECUTABLE` before every rebuild. This way you can easily use other tools like _elm-css_ or _browserify_ in your workflow.
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "cross-spawn": "^5.0.1",
     "hasbin": "^1.2.1",
     "indent-string": "^3.0.0",
+    "middleware-proxy": "^2.0.2",
     "q-stream": "^0.2.0"
   },
   "scripts": {

--- a/source/elm-live.js
+++ b/source/elm-live.js
@@ -174,7 +174,8 @@ ${dim("elm-live:")}
 
 `
     );
-    const server = budo({
+
+    const serverConfig = {
       live: true,
       watchGlob: path.join(args.dir, "**/*.{html,css,js}"),
       port: args.port,
@@ -183,7 +184,18 @@ ${dim("elm-live:")}
       dir: args.dir,
       stream: outputStream,
       pushstate: args.pushstate
-    });
+    }
+
+    if (args.proxyPathPrefix && args.proxyHost) {
+      const proxy = require('middleware-proxy');
+      if (args.proxyStripPrefix) {
+        serverConfig.middleware = [proxy(args.proxyPathPrefix, args.proxyHost, args.proxyStripPrefix)];
+      } else {
+        serverConfig.middleware = [proxy(args.proxyPathPrefix, args.proxyHost)];
+      }
+    }
+
+    const server = budo(serverConfig);
     server.on("error", error => {
       throw error;
     });

--- a/source/parse-args.js
+++ b/source/parse-args.js
@@ -59,6 +59,15 @@ module.exports = argv => {
       return true;
     }
 
+    const proxyPattern = /^--proxy=(.+?)::(.+?)(::(.+))?$/;
+    const proxyMatch = arg.match(proxyPattern);
+    if (proxyMatch) {
+      args.proxyPathPrefix = proxyMatch[1];
+      args.proxyHost = proxyMatch[2];
+      args.proxyStripPrefix = proxyMatch[4];
+      return true
+    }
+
     if (arg === "--") {
       const elmMakeRest = argv.slice(index + 1);
       elmMakeRest.forEach(elmMakeArg => elmMakeArgs.push(elmMakeArg));


### PR DESCRIPTION
This uses the [middleware-proxy](https://www.npmjs.com/package/middleware-proxy) middleware to proxy requests from a path prefix to another server.

This is immensely helpful when developing a frontend and a backend simultaneously.

I am not completely sold on the `::` separator, so if you guys prefer something else, feel free to change it  😄

I haven't updated package-lock.json, since I use `yarn`, and didn't want to mess anything up.