### PR TITLE
work around commander arg bug

### DIFF
--- a/bin/elm-live.js
+++ b/bin/elm-live.js
@@ -7,7 +7,7 @@ program
   .version(require('../package.json').version)
   .arguments('<elm-main>')
   .usage(`${chalk.magenta('<elm-main>')} [options] [--] [elm make options]`)
-  .option('-p, --port [port]', 'The port to bind to.', parseInt, 8000)
+  .option('-p, --port [port]', 'The port to bind to.', parseInt)
   .option('-e, --path-to-elm [path-to-elm]', 'An absolute or relative path to elm. If you’ve installed elm locally with npm you’ll want to set this to `node_modules/.bin/elm`.', 'elm')
   .option('-h, --host [host]', 'Set the host interface to attach the server to.', 'localhost')
   .option('-d, --dir [dir]', 'The base for static content.', process.cwd())


### PR DESCRIPTION
This PR restores the ability in elm-live to override the default port of 8000.

This appears ultimately to be due to an issue in commander.

My fix here is to remove the use of the commander default value (which isn't working and ends up parsing port values as NaN), and rely instead on the source/elm-live.js default value logic.