### PR TITLE
Adding catch for elm make --output flag being used in wrong location

### DIFF
--- a/bin/elm-live.js
+++ b/bin/elm-live.js
@@ -38,5 +38,31 @@ program
   })
   .parse(process.argv)
 
-const elmLive = require('../lib/src/elm-live')
-elmLive(program, { inputStream: process.stdin, outputStream: process.stdout })
+function hasBadOutput ([val, done], arg) {
+  if (done) {
+    return [val, done]
+  } else if (arg === '--') {
+    return [val, true]
+  }
+
+  return arg.includes('--output') ? [true, true] : [false, false]
+}
+
+const [ isBadOutput ] = program.rawArgs.reduce(hasBadOutput, [false, false])
+
+if (isBadOutput) {
+  console.log(``)
+  console.log(chalk.red.bold(`----------------------`))
+  console.log(chalk.red.bold(`|| ERROR IN COMMAND ||`))
+  console.log(chalk.red.bold(`----------------------`))
+  console.log(``)
+  console.log(`Usage: ${chalk.blue('<elm-main> [options] [--] [elm make options]')}`)
+  console.log(``)
+  console.log(`You have used the ${chalk.blue('elm make')} flag --output in the wrong location. As seen in the usage example about, all ${chalk.blue('elm make')} flags must be added to your command after the -- separator.`)
+  console.log(``)
+  console.log(``)
+  console.log(``)
+} else {
+  const elmLive = require('../lib/src/elm-live')
+  elmLive(program, { inputStream: process.stdin, outputStream: process.stdout })
+}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "files": [
     "lib/index.js",
     "lib/src/**/*.js",
-    "bin/elm-live.js"
+    "bin/elm-live.js",
+    "License.md"
   ],
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
I have been hearing of a number of issues with people having trouble with where to put the --output flag. Now there is an error that won't let you put it in the wrong place! 👌