### PR TITLE
Glob pattern on windows

### DIFF
--- a/lib/src/get-source-dirs.js
+++ b/lib/src/get-source-dirs.js
@@ -8,7 +8,7 @@ function getSourceDirs (packageFilePath) {
     const elmPackage = JSON.parse(fs.readFileSync(packageFilePath))
     const sourceDirs = elmPackage['source-directories']
     if (sourceDirs !== undefined) {
-      return sourceDirs.map(dir => path.join(dir, '/**/*.elm'))
+      return sourceDirs.map(dir => path.join(dir, '/**/*.elm').replace(/\\/g, '/'))
     } else {
       return defaultElmDirs
     }


### PR DESCRIPTION
Solve #170.

Since chokidar doesn't allow backward slashes in glob patterns (see https://github.com/paulmillr/chokidar/issues/668#issuecomment-357235531), replace all `\`, generated under windows when using `path.join`, with `/`.