### PR TITLE
Handle proxy failures by logging and returning 502

### DIFF
--- a/lib/src/start.js
+++ b/lib/src/start.js
@@ -177,6 +177,10 @@ function handler (model) {
         target: model.proxyHost,
         changeOrigin: true,
         hostRewrite: true
+      }, function(err) {
+        console.log("Proxy failure :", err.message)
+        res.writeHead(502)
+        res.end("502 Bad Gateway")
       })
     } else if (url.isType(CONTENT_TYPE)) {
       readFile(url.getPath, 'utf8')


### PR DESCRIPTION
Previously elm-live would crash, since this is the default http-proxy behaviour in the case that an error handler is not defined.

### Current behaviour

When the proxied host fails to accept a connection, elm-live crashes with

	...<snip>.../node_modules/http-proxy/lib/http-proxy/index.js:120
	    throw err;
	    ^

	Error: connect ECONNREFUSED 127.0.0.1:4567
	    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1106:14)

### Use case and desired behaviour

For example, when proxying to a local development server which may need to restart to load new code, we don't want elm-live to crash.

Desired behaviour:

* elm-live prints a warning (to make debugging easy)
* The incoming HTTP request is closed with an appropriate status

## Behaviour with this PR

Elm-live does not crash :)

Elm-live logs the failure:

	Proxy failure : connect ECONNREFUSED 127.0.0.1:4567

The incoming HTTP request is closed with 502 Bad Gateway

	$ http get http://localhost:8000/api/path
	HTTP/1.1 502 Bad Gateway
	Connection: keep-alive
	Date: Fri, 09 Aug 2019 11:38:19 GMT
	Transfer-Encoding: chunked
