### PR TITLE
Add X-Forwarded- headers to upstream request

### DIFF
--- a/lib/src/start.js
+++ b/lib/src/start.js
@@ -176,7 +176,8 @@ function handler (model) {
       proxy.web(req, res, {
         target: model.proxyHost,
         changeOrigin: true,
-        hostRewrite: true
+        hostRewrite: true,
+        xfwd: true // Adds X-Forwarded-*: headers to upstream request
       }, function (err) {
         console.log('Proxy failure :', err.message)
         res.writeHead(502)


### PR DESCRIPTION
This will help improve compatibility with upstream servers.

In my specific case when using Ruby & Sinatra, these headers allow Sinatra to handle session CSRF protection correctly.