### PR TITLE
Fix that move the injected html snippet (that load reload.js) at the …

### DIFF
--- a/lib/src/start.js
+++ b/lib/src/start.js
@@ -127,9 +127,9 @@ const resolveWith = res => contents => {
   res.setHeader('Content-Type', 'text/html')
   res.end(`${contents}
 
-<!-- Inserted by Reload -->
+<!-- Inserted by elm-live -->
 <script src="/reload/reload.js"></script>
-<!-- End Reload -->
+<!-- Inserted by elm-live - END -->
 `)
 }
 

--- a/lib/src/start.js
+++ b/lib/src/start.js
@@ -125,13 +125,11 @@ function parseUrl (pathname, model) {
  **/
 const resolveWith = res => contents => {
   res.setHeader('Content-Type', 'text/html')
-  res.end(`
+  res.end(`${contents}
 
 <!-- Inserted by Reload -->
 <script src="/reload/reload.js"></script>
 <!-- End Reload -->
-
-${contents}
 `)
 }
 


### PR DESCRIPTION
…end of the html file instead that at the top. Injecting at the top it causes browser not behaving properly because the first line is not "<!DOCTYPE html>" anymore