### PR TITLE
Fix error when elm binary wasn't found.

### DIFF
--- a/lib/src/build.js
+++ b/lib/src/build.js
@@ -6,7 +6,7 @@ const { pipe } = require('crocks/helpers')
 const spawn = require('cross-spawn')
 const { inject } = require('elm-hot')
 const { PROCESS_SUCCESS, update, readFile, writeFile } = require('./utils')
-const { elmNotFound, errorMsg, compileError, buildError, buildSuccess } = require('./messages')
+const { elmNotFound, commandError, compileError, buildError, buildSuccess } = require('./messages')
 
 /*
 |-------------------------------------------------------------------------------
@@ -97,10 +97,10 @@ const runElm = model => Async((reject, resolve) => {
   proc.stderr.on('data', data => update(result, { data: result.data + data }))
 
   proc.on('error', function (error) {
-    if (error.name === 'ENOENT') {
+    if (error.code === 'ENOENT') {
       reject(elmNotFound(model.elm))
     } else {
-      reject(errorMsg(model.elm, error, model.recover))
+      reject(commandError(model.elm, error))
     }
   })
 

--- a/lib/src/messages.js
+++ b/lib/src/messages.js
@@ -127,16 +127,16 @@ ${header}
 `
 
 module.exports = {
-  hotReloadOn,
+  buildError,
+  buildSuccess,
+  commandError,
+  compileError,
+  elmNotFound,
+  eventNotification,
   flagError,
   flagErrorMsgs,
   help,
-  commandError,
-  elmNotFound,
-  buildError,
-  buildSuccess,
-  watchingDirs,
-  eventNotification,
-  compileError,
-  serverStarted
+  hotReloadOn,
+  serverStarted,
+  watchingDirs
 }


### PR DESCRIPTION
The `errorMsg` function being used is never exported
by the messages module. Furthermore, the error
being raised by the cross-spawn helper populates
the `code` property, not the `name` prop.

I think this resolved #201. It at least solves the problem for me when using elm 0.19.1 and not having it on the PATH.