### PR TITLE
Skip processing fs change events when building instead of using `debounce` to avoid problems

### DIFF
--- a/lib/src/build.js
+++ b/lib/src/build.js
@@ -92,6 +92,7 @@ const runElm = model => Async((reject, resolve) => {
     data: ''
   }
 
+  model.__building = true
   const proc = spawn(model.elm, ['make', '--report=json', ...model.elmArgs])
 
   proc.stderr.on('data', data => update(result, { data: result.data + data }))
@@ -105,6 +106,7 @@ const runElm = model => Async((reject, resolve) => {
   })
 
   proc.on('exit', function (status) {
+    model.__building = false
     if (status !== PROCESS_SUCCESS) {
       try {
         const parsedData = JSON.parse(result.data)

--- a/lib/src/watch.js
+++ b/lib/src/watch.js
@@ -114,7 +114,9 @@ const watch = model => Async((reject, _) => {
 
   watcher.on(
     'all',
-    debounce((event, filePath) => {
+    (event, filePath) => {
+      if (model.__building) return
+
       const relativePath = path.relative(process.cwd(), filePath)
       const eventName = eventNameMap[event] || event
       const eventMsg = eventNotification(eventName, relativePath)
@@ -141,8 +143,7 @@ const watch = model => Async((reject, _) => {
         .map(when(getPropOr(true, 'useServer'), sendMessage))
         .map(maybeUpdateToWatching)
         .fork(closeAndReject, watch)
-    }),
-    100
+    }
   )
 })
 


### PR DESCRIPTION
When build step gets longer than debounce wait, the file system changes by build causes the build to be run again; causing infinite loop.

I don't think the solution is to extend debounce wait.

Instead, with a condition variable (skip processing fs events while we are "building"), we no longer need debounce and can even avoid infinite loop situations too.

---

NOTES
- `elm make` is fast, but when a project starts adding [code](https://github.com/harmboschloo/graphql-to-elm) [generators](https://gist.github.com/choonkeat/b9959168e15d813d9f8a84d0e2c9632a#gistcomment-2749763) we could cross that threshold easily
- if sticking a `__building` property to `model` is not preferred, feel free to restructure