### PR TITLE
Ignore query strings for static files (fixes #199)

### DIFF
--- a/lib/src/start.js
+++ b/lib/src/start.js
@@ -10,7 +10,7 @@ const os = require('os')
 const path = require('path')
 const serveStatic = require('serve-static')
 const ws = require('ws')
-const { update, readFile, notExists, writeFile, isObj, hasProp } = require('./utils')
+const { update, readFile, notExists, writeFile, isObj, hasProp, removeQueryString } = require('./utils')
 const { fileNotFound, serverStarted } = require('./messages')
 
 /*
@@ -106,7 +106,11 @@ function getRequestType ({ pathname, fileType }, { proxyPrefix, pushstate }) {
  * This function takes in the path from the request and the model and returns the needed values to finish running the request.
  **/
 function parseUrl (pathname, model) {
-  const fileType = pipe(path.extname, mime.getType)(pathname)
+  let fileType = pipe(path.extname, mime.getType)(pathname)
+  if (fileType === null) {
+    // prevent static files with query strings having a null fileType and thus returning the wrong request type from getRequestType
+    fileType = pipe(path.extname, mime.getType)(removeQueryString(pathname))
+  }
   const requestType = getRequestType({ pathname, fileType }, model)
   const rootPath = `${model.dir}/${model.startPage}`
   const fullPath = `${model.dir}${pathname}`

--- a/lib/src/utils.js
+++ b/lib/src/utils.js
@@ -49,6 +49,8 @@ const debounce = (func, wait) => {
   }
 }
 
+const removeQueryString = (url) => url.split('?')[0]
+
 module.exports = {
   when,
   update,
@@ -63,6 +65,7 @@ module.exports = {
   empty,
   noop,
   hasProp,
+  removeQueryString,
   PROCESS_SUCCESS,
   PROCESS_FAILURE
 }


### PR DESCRIPTION
If static files were requested with query strings (e.g. `/static/bootstrap.min.css?12345`) their `fileType` was `null`.

With `--pushstate` enabled, this resulted in the `getRequestType` function returning `CONTENT_TYPE` instead of `STATIC_TYPE` which meant the fallback `index.html` was served instead of the correct static resource.

This fixes #199.