### PR TITLE
Don't consider nonexistant files as static

### DIFF
--- a/lib/src/start.js
+++ b/lib/src/start.js
@@ -172,9 +172,9 @@ function handler (model) {
   const serve = serveStatic(model.dir, { index: ['index.html', 'index.htm'] })
 
   return function (req, res) {
-    const url = parseUrl(req.url, model)
+    const urlInfo = parseUrl(req.url, model)
 
-    if (proxy && url.isType(PROXY_TYPE)) {
+    if (proxy && urlInfo.isType(PROXY_TYPE)) {
       req.url = req.url.replace(model.proxyPrefix, '')
       proxy.web(req, res, {
         target: model.proxyHost,
@@ -186,11 +186,11 @@ function handler (model) {
         res.writeHead(502)
         res.end('502 Bad Gateway')
       })
-    } else if (url.isType(CONTENT_TYPE)) {
-      readFile(url.getPath, 'utf8')
-        .alt(readFile(url.rootpath, 'utf8'))
+    } else if (urlInfo.isType(CONTENT_TYPE)) {
+      readFile(urlInfo.getPath, 'utf8')
+        .alt(readFile(urlInfo.rootpath, 'utf8'))
         .fork(resolveNotFound(res), resolveWith(model.reload, res))
-    } else if (url.isType(RELOAD_TYPE)) {
+    } else if (urlInfo.isType(RELOAD_TYPE)) {
       readFile(RELOAD_FILE, 'utf8')
         .map(file => file.replace(`'{{verbose}}'`, `${model.verbose}`))
         .map(file => file.replace(`'{{reload}}'`, `${model.reload}`))

--- a/lib/src/start.js
+++ b/lib/src/start.js
@@ -193,7 +193,7 @@ function handler (model) {
       })
     } else if (urlInfo.isType(CONTENT_TYPE)) {
       readFile(urlInfo.getPath, 'utf8')
-        .alt(readFile(urlInfo.rootpath, 'utf8'))
+        .alt(readFile(urlInfo.rootPath, 'utf8'))
         .fork(resolveNotFound(res), resolveWith(model.reload, res))
     } else if (urlInfo.isType(RELOAD_TYPE)) {
       readFile(RELOAD_FILE, 'utf8')

--- a/lib/src/start.js
+++ b/lib/src/start.js
@@ -9,6 +9,7 @@ const mime = require('mime')
 const os = require('os')
 const path = require('path')
 const serveStatic = require('serve-static')
+const { URL } = require('url')
 const ws = require('ws')
 const { update, readFile, notExists, writeFile, isObj, hasProp } = require('./utils')
 const { fileNotFound, serverStarted } = require('./messages')
@@ -172,7 +173,8 @@ function handler (model) {
   const serve = serveStatic(model.dir, { index: ['index.html', 'index.htm'] })
 
   return function (req, res) {
-    const urlInfo = parseUrl(req.url, model)
+    const url = new URL(req.url, `http://${req.headers.host}`)
+    const urlInfo = parseUrl(url.pathname, model)
 
     if (proxy && urlInfo.isType(PROXY_TYPE)) {
       req.url = req.url.replace(model.proxyPrefix, '')

--- a/lib/src/start.js
+++ b/lib/src/start.js
@@ -3,6 +3,7 @@ const { ifElse } = require('crocks/logic')
 const { pipe } = require('crocks/helpers')
 const { map } = require('crocks/pointfree')
 const finalhandler = require('finalhandler')
+const fs = require('fs')
 const http = require('http')
 const https = require('https')
 const mime = require('mime')
@@ -91,6 +92,7 @@ function getRequestType ({ pathname, fileType }, { proxyPrefix, pushstate }) {
     return PROXY_TYPE
   } else if (
     isRoot({ pathname, pushstate, fileType }) ||
+    fileType === null ||
     fileType === 'text/html'
   ) {
     return CONTENT_TYPE
@@ -107,7 +109,8 @@ function getRequestType ({ pathname, fileType }, { proxyPrefix, pushstate }) {
  * This function takes in the path from the request and the model and returns the needed values to finish running the request.
  **/
 function parseUrl (pathname, model) {
-  const fileType = pipe(path.extname, mime.getType)(pathname)
+  const fileExists = fs.existsSync(path.join(model.dir, pathname))
+  const fileType = fileExists ? pipe(path.extname, mime.getType)(pathname) : null
   const requestType = getRequestType({ pathname, fileType }, model)
   const rootPath = `${model.dir}/${model.startPage}`
   const fullPath = `${model.dir}${pathname}`


### PR DESCRIPTION
Fixes #209.

- Only examine URL `pathname` when deciding whether a request should be handled statically.
- If a file does not exist, don't try to serve it statically.

I'm pretty sure that the first fix, where we no longer regard the query string when examining what to do with a path, is good and correct.

However, having implemented the behavior where we only consider serving a file statically if it actually exists, I'm not sure how I actually like it. This behavior means we serve a 200 with a gibberish response on any incorrect path to an asset, which makes certain problems harder to find. On the other hand, it doesn't seem unreasonable for an Elm application to want to masquerade as e.g. ASP.NET or PHP, in which case it might want to serve URLs that end in e.g. `.aspx` or `.php`. It might make sense to carve out exceptions for certain well-known file types such as CSS, JS, `.ico`, `.png`, `.jpg`, or alternately revert this behavior entirely and make people like me put email addresses as query string arguments instead of paths. Thoughts?