### PR TITLE
Add option to watch all files in a directory.

### DIFF
--- a/License.md
+++ b/License.md
@@ -1,4 +1,4 @@
-Copyright © 2018 William King, 2018 Alex Korban, 2015-2018 Tomek Wiszniewski, 2016 Brian Dukes
+Copyright © 2018 William King, 2018 Alex Korban, 2015-2018 Tomek Wiszniewski, 2016 Brian Dukes, 2020 David Muhr
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/Readme.md
+++ b/Readme.md
@@ -108,6 +108,9 @@ Proxy requests to another server running at `HOST`. Requires `--proxy-prefix` an
 #### `-d, --dir=PATH`
 The base for static content. Default: `.`.
 
+#### `-w, --watch`
+Watches all files in the specified or default directory and triggers a reload if files change.
+
 #### `-s, --start-page=PATH`
 A custom html file to serve other than the default `index.html`.
 

--- a/bin/elm-live.js
+++ b/bin/elm-live.js
@@ -37,6 +37,7 @@ program
 
   // Booleans
   .option('-u, --pushstate [pushstate]', `Forces the index.html or whatever filename you have passed to the --start-page flag to always be served. Must be used when building with ${chalk.cyan.underline('Browser.application')}.`, false)
+  .option('-w, --watch [watch]', 'Watches all files in the specified or default directory and triggers a reload if files change.', false)
   .option('-H, --hot [hot]', 'Turn on hot module reloading.', false)
   .option('-o, --open [open]', 'Open in browser when server starts.', false)
   .option('-v, --verbose [verbose]', 'Will log more steps as your server starts up.', false)

--- a/lib/src/init.js
+++ b/lib/src/init.js
@@ -30,6 +30,7 @@ const init = program => ({
   build: false,
   cwd: process.cwd(),
   dir: program.dir || process.cwd(),
+  watch: program.watch || false,
   elm: program.pathToElm || 'elm',
   elmArgs: program.args || [],
   getAction: key => ({

--- a/lib/src/watch.js
+++ b/lib/src/watch.js
@@ -98,18 +98,22 @@ const websocketWatcher = model => Async((reject, resolve) => {
 const watch = model => Async((reject, _) => {
   const sources = getSources()
 
-  model.log(watchingDirs(sources))
-
   if (model.useServer) {
     websocketWatcher(model)
       .map(maybeUpdateToWatching)
       .fork(model.log, noop)
   }
 
-  const watcher = chokidar.watch([...sources, ...packageFileNames], {
+  const watchTargets = model.watch
+    ? [model.dir, ...sources, ...packageFileNames]
+    : [...sources, ...packageFileNames]
+
+  model.log(watchingDirs(watchTargets))
+
+  const watcher = chokidar.watch(watchTargets, {
     ignoreInitial: true,
     followSymlinks: false,
-    ignored: ['elm-stuff/generated-code/*', /ElmjutsuDumMyM0DuL3.elm/, /\/.#[^/]+\.elm/]
+    ignored: [new RegExp(model.target), /.git/, /.vscode/, /.idea/, /node_modules/, /elm-stuff/, /ElmjutsuDumMyM0DuL3.elm/, /\/.#[^/]+\.elm/]
   })
 
   watcher.on(


### PR DESCRIPTION
Hey!

This pull request adds an option to watch for all file changes in the specified or default directory.

#### `-w, --watch`
Watches all files in the specified or default directory and triggers a reload if files change.

To work with the current working directory we have to ignores some common paths that may exist there (node_modules, .git, ...). Let's discuss what paths we should ignore by default or if we should only allow watching subdirectories.