### PR TITLE
Fix path extension parsing

### DIFF
--- a/lib/src/start.js
+++ b/lib/src/start.js
@@ -101,12 +101,21 @@ function getRequestType ({ pathname, fileType }, { proxyPrefix, pushstate }) {
 }
 
 /**
+ * getPathExtension :: String -> String
+ *
+ * Returns extension of a given path, e.g. "/" -> "", "/main.js" -> ".js", "/main.js?v1" -> ".js"
+ */
+function getPathExtension (pathname) {
+  return pathname.split(/#|\?/)[0].split('.').pop()
+}
+
+/**
  * parseUrl :: (String, Model) -> { fullPath: String, getPath: String, isRoot: Bool, isType: String -> Bool}
  *
  * This function takes in the path from the request and the model and returns the needed values to finish running the request.
  **/
 function parseUrl (pathname, model) {
-  const fileType = pipe(path.extname, mime.getType)(pathname)
+  const fileType = pipe(getPathExtension, mime.getType)(pathname)
   const requestType = getRequestType({ pathname, fileType }, model)
   const rootPath = `${model.dir}/${model.startPage}`
   const fullPath = `${model.dir}${pathname}`


### PR DESCRIPTION
Currently some paths are not served correctly, e.g. "/main.js?v1" or "/main.js?v1.xml". This PR fixes these issues by taking into consideration characters that might come after the file extension.