### PR TITLE
Fix a variable name that cause elm-live to crash in several circumstances

### DIFF
--- a/lib/src/start.js
+++ b/lib/src/start.js
@@ -197,7 +197,7 @@ function handler (model) {
       })
     } else if (url.isType(CONTENT_TYPE)) {
       readFile(url.getPath, 'utf8')
-        .alt(readFile(url.rootpath, 'utf8'))
+        .alt(readFile(url.rootPath, 'utf8'))
         .fork(resolveNotFound(res), resolveWith(model.reload, res))
     } else if (url.isType(RELOAD_TYPE)) {
       readFile(RELOAD_FILE, 'utf8')


### PR DESCRIPTION
This is causing elm-live to crash with error
```
internal/fs/utils.js:581
    throw new ERR_INVALID_ARG_TYPE(propName, ['string', 'Buffer', 'URL'], path);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string or an instance of Buffer or URL. Received undefined
    at readFile (fs.js:317:10)
    at /Users/lucamug/p/elm-live/node_modules/crocks/Async/index.js:54:10
    at Object.fork (/Users/lucamug/p/elm-live/node_modules/crocks/Async/index.js:155:20)
    at /Users/lucamug/p/elm-live/node_modules/crocks/Async/index.js:254:41
    at settle (/Users/lucamug/p/elm-live/node_modules/crocks/Async/index.js:151:16)
    at ReadFileContext.callback (/Users/lucamug/p/elm-live/node_modules/crocks/Async/index.js:56:47)
    at FSReqCallback.readFileAfterOpen [as oncomplete] (fs.js:261:13) {
  code: 'ERR_INVALID_ARG_TYPE'
}```