### PR TITLE
Fix `url.rootpath` typo

### DIFF
--- a/lib/src/start.js
+++ b/lib/src/start.js
@@ -197,7 +197,7 @@ function handler (model) {
       })
     } else if (url.isType(CONTENT_TYPE)) {
       readFile(url.getPath, 'utf8')
-        .alt(readFile(url.rootpath, 'utf8'))
+        .alt(readFile(url.rootPath, 'utf8'))
         .fork(resolveNotFound(res), resolveWith(model.reload, res))
     } else if (url.isType(RELOAD_TYPE)) {
       readFile(RELOAD_FILE, 'utf8')


### PR DESCRIPTION
When starting up elm-live, I got this error:
```
internal/fs/utils.js:581
    throw new ERR_INVALID_ARG_TYPE(propName, ['string', 'Buffer', 'URL'], path);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string or an instance of Buffer or URL. Received undefined
    at readFile (fs.js:317:10)
    at /home/path/to/node_modules/crocks/Async/index.js:54:10
    at Object.fork (/home/path/to/node_modules/crocks/Async/index.js:155:20)
    at /home/path/to/node_modules/crocks/Async/index.js:254:41
    at settle (/home/path/to/node_modules/crocks/Async/index.js:151:16)
    at ReadFileContext.callback (/home/path/to/node_modules/crocks/Async/index.js:56:47)
    at FSReqCallback.readFileAfterOpen [as oncomplete] (fs.js:261:13) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

After finding where the call occurred and console logging the stringified `url` object I got this output:
```
{
    "rootPath": "public/index.html",
    "getPath": "public/index.html",
    "isRoot": true
}
```

Based on the above, it looks like `url.rootpath` is a typo, so I fixed it.