### PR TITLE
Implemented option to watch other non-elm files and auto-reload on changes

### DIFF
--- a/bin/elm-live.js
+++ b/bin/elm-live.js
@@ -15,6 +15,7 @@ program
   // Server
   .option('-p, --port [port]', 'The port to bind to.', Math.floor, 8000)
   .option('-h, --host [host]', 'Set the host interface to attach the server to.', 'localhost')
+  .option('-w, --watch [to-watch]', 'Specify additional directories or files to watch for changes. (comma separated list)', v => v.split(','))
 
   // SSL
   .option('-S, --ssl [ssl]', 'Start an https server instead of http.', false)

--- a/lib/src/init.js
+++ b/lib/src/init.js
@@ -53,6 +53,7 @@ const init = program => ({
   ssl: parseSsl(program),
   startPage: program.startPage || 'index.html',
   target: parseOutput(program.args),
+  toWatch: program.watch || [],
   verbose: program.verbose || false
 })
 

--- a/lib/src/messages.js
+++ b/lib/src/messages.js
@@ -107,8 +107,8 @@ const watchingDirs = sourceDirs =>
     .join('\n    ')}
 `
 
-const eventNotification = (event, path) => (isBrowser = false) => {
-  const msg = `You’ve ${event} \`${path}\`. Rebuilding!`
+const eventNotification = (event, path, action = 'Rebuilding') => (isBrowser = false) => {
+  const msg = `You’ve ${event} \`${path}\`. ${action}!`
   return isBrowser ? msg
     : `${header}
   ${msg}

--- a/lib/src/watch.js
+++ b/lib/src/watch.js
@@ -126,11 +126,13 @@ const watch = model => Async((reject, _) => {
         // Package file changes may result in changes to the set
         // of watched files
         watcher.close()
+        if(additionalWatcher) additionalWatcher.close()
         watch(model)
       }
 
       function closeAndReject (x) {
         watcher.close()
+        if(additionalWatcher) additionalWatcher.close()
         reject(x)
       }
 
@@ -145,6 +147,30 @@ const watch = model => Async((reject, _) => {
         .fork(closeAndReject, watch)
     }
   )
+
+  /**
+   * This watcher only watches the files and directories passed by the --watch flag.
+   * These files are watched on its own watcher because changes to them shouldn't trigger an rebuild of the project, only a reload of the page.
+   */
+  const additionalWatcher = model.toWatch.length ?
+    chokidar.watch(model.toWatch, {
+      ignoreInitial: true,
+      followSymlinks: false,
+    }).on(
+      'all',
+      debounce((event, filePath) => {
+        const relativePath = path.relative(process.cwd(), filePath)
+        const eventName = eventNameMap[event] || event
+        const eventMsg = eventNotification(eventName, relativePath, 'Reloading')
+        model.log(eventMsg())
+
+        if (getPropOr(true, 'useServer')())
+          sendMessage(update(model, { build: { action: model.getAction('reload') } }));
+        maybeUpdateToWatching(model)
+      }),
+      100
+    ) : null
+
 })
 
 module.exports = {


### PR DESCRIPTION
With this change, you can use the `--watch` (or `-w`) option to watch any directory or file of your choice, and the browser will reload in response to any changes on them

This is really useful for when you're editing a CSS file, with it, you're able to see your changes in the browser without having to reload the page

Usage example:
```shell
elm-live src/Main.elm --dir=./public --watch public/* -- --output=public/build/main.js
```

You can watch multiple directories/files by separating them with commas:
```shell
elm-live src/Main.elm --dir=./public --watch public/*,someotherdir/* -- --output=public/build/main.js
```