### PR TITLE
Fixed bug for pages without `head` tags

### DIFF
--- a/lib/src/start.js
+++ b/lib/src/start.js
@@ -15,7 +15,7 @@ const { fileNotFound, serverStarted } = require('./messages')
 
 /*
 |-------------------------------------------------------------------------------
-| Relaod
+| Reload
 |-------------------------------------------------------------------------------
 */
 
@@ -143,7 +143,7 @@ ${reload ? `
 <script src="/reload/reload.js"></script>
 <!-- End Reload -->
 ` : ''}
-${after}
+${after || ""}
 `)
 }
 


### PR DESCRIPTION
When you do
```js
const [before, after] = "some html string that doesn't contain head".split("<head>")
```
`after` is undefined, and ``${after}`` will leave the text node `undefined` visible in the dom.
